### PR TITLE
Fix Garbled String Encoding for Archive Entries

### DIFF
--- a/ZippyZap/ZZOldArchiveEntry.mm
+++ b/ZippyZap/ZZOldArchiveEntry.mm
@@ -250,9 +250,23 @@
 
 - (NSString*)fileNameWithEncoding:(NSStringEncoding)encoding
 {
-	return [[NSString alloc] initWithBytes:_centralFileHeader->fileName()
-									length:_centralFileHeader->fileNameLength
-								  encoding:encoding];
+	NSString *encodedString = nil;
+	
+	if (encoding == CFStringConvertEncodingToNSStringEncoding(kCFStringEncodingDOSLatinUS)) {
+		BOOL lossyConversion = NO;
+		NSData *data = [NSData dataWithBytesNoCopy:_centralFileHeader->fileName()
+											length:_centralFileHeader->fileNameLength
+									  freeWhenDone:NO];
+		[NSString stringEncodingForData:data
+						encodingOptions:nil
+						convertedString:&encodedString
+					usedLossyConversion:&lossyConversion];
+	} else {
+		encodedString = [[NSString alloc] initWithBytes:_centralFileHeader->fileName()
+												 length:_centralFileHeader->fileNameLength
+											   encoding:encoding];
+	}
+	return encodedString;
 }
 
 - (BOOL)checkEncryptionAndCompression:(out NSError**)error


### PR DESCRIPTION
Attempts to convert the filename for an entry to a readable format when the encoding isn't US Latin.